### PR TITLE
fix: only apply the AppExport transformation to the actual `root.tsx` file

### DIFF
--- a/src/vite/plugin.tsx
+++ b/src/vite/plugin.tsx
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { Plugin, normalizePath } from "vite";
 import { parse } from "es-module-lexer";
 
@@ -7,7 +8,6 @@ import { DevToolsServerConfig } from "../server/config.js";
 import { handleDevToolsViteRequest, /**processPlugins */ } from "./utils.js";
 import { ActionEvent, LoaderEvent } from "../server/event-queue.js"; 
 import { RdtClientConfig } from "../client/context/RDTContext.js"; 
-import path from "node:path";
 
 declare global {
   interface Window {
@@ -36,7 +36,7 @@ export const remixDevTools: (args?:RemixViteConfig) => Plugin[] = (args) => {
   const include = args?.includeInProd??false;
 //  const plugins = pluginDir ? processPlugins(pluginDir) : [];
  // const pluginNames = plugins.map((p) => p.name);
-  let rootDir = process.cwd();
+  let rootDir:string;
   const shouldInject = (mode: string | undefined) => mode === "development" || include;
   let port = 5173;
   return [


### PR DESCRIPTION
# Description

I encountered an issue where any files matching the pattern `*root.tsx` were being treated as the `app/root.tsx` and receiving the same transformation.

This resolves this issue by only matching on the exact path of the app `root.tsx` file based on the Vite root directory and the Remix `appDirectory`.

**Before**

Root transforms are applied to any file matching `**/*root.tsx`:

- `app/root.tsx` ✅ 
- `app/components/card-root.tsx` ✅ 
- `app/routes/_auth.root.tsx` ✅ 

**After**

Root transforms are only applied to the _actual_ `root.tsx` file as determined by Remix

- `app/root.tsx` ✅ 
- `app/components/card-root.tsx` 🚫
- `app/routes/_auth.root.tsx` 🚫


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?

I have an app with files such as:

- `app/root.tsx`
- `app/components/card-root.tsx`
- `app/components/dialog-root.tsx`

Using this plugin before this change caused the following error: `AppExport is not defined`

With these changes, the app runs and the dev tools are correctly included in the running app.

- [ ] Unit tests

# Checklist:

- [x] My code follows the guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
