### PR TITLE
Use Inherit To Preserve Text Color

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remix-development-tools",
-  "version": "4.1.6",
+  "version": "4.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "remix-development-tools",
-      "version": "4.1.6",
+      "version": "4.2.1",
       "license": "MIT",
       "workspaces": [
         ".",

--- a/src/input.css
+++ b/src/input.css
@@ -169,7 +169,7 @@ Prevent `sub` and `sup` elements from affecting the line height in all browsers.
   /* 1 */
   line-height: inherit;
   /* 1 */
-  color: initial;
+  color: inherit;
   /* 1 */
   margin: 0;
   /* 2 */


### PR DESCRIPTION
# Description

Browser defaults or project overrides for text color can cause the UI to become nearly unreadable when color is set to use `initial` values. 
<img width="1274" alt="Screenshot 2024-06-25 at 2 15 28 PM" src="https://github.com/forge42dev/Remix-Dev-Tools/assets/130303310/b51af636-5d8c-4981-a8f9-e27bd1dd5add">

Switching the color to use `inherit` (which is used everywhere else in the css), resolves the issue.
<img width="1318" alt="Screenshot 2024-06-25 at 2 15 43 PM" src="https://github.com/forge42dev/Remix-Dev-Tools/assets/130303310/0c49be0c-3f44-42a9-8c2a-b14af3ba3e1a">


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Verified before and after changes that the UI looks correct and that the issue is resolved, in Chrome, Firefox, and Safari.


# Checklist:

- [x] My code follows the guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
