### PR TITLE
Fix/ open in VSCode for folder routes

### DIFF
--- a/src/client/components/RouteSegmentInfo.tsx
+++ b/src/client/components/RouteSegmentInfo.tsx
@@ -6,11 +6,11 @@ import { CacheInfo } from "./CacheInfo.js";
 import { VsCodeButton } from "./VScodeButton.js";
 import { JsonRenderer } from "./jsonRenderer.js";
 import { ServerRouteInfo, defaultServerRouteState } from "../context/rdtReducer.js";
-
 import { InfoCard } from "./InfoCard.js";
 import { useDevServerConnection } from "../hooks/useDevServerConnection.js";
 import { Icon } from "./icon/Icon.js";
 import clsx from "clsx";
+import { OpenSourceData } from "../../vite/types.js";
 
 const getLoaderData = (data: string | Record<string, any>) => {
   if (typeof data === "string") {
@@ -118,8 +118,8 @@ export const RouteSegmentInfo = ({ route, i }: { route: UIMatch<unknown, unknown
               onClick={() =>
                 sendJsonMessage({
                   type: "open-source",
-                  data: { source: `app/${route.id}` },
-                })
+                  data: { routeID: route.id },
+                } satisfies OpenSourceData)
               }
             />
           )}

--- a/src/test-apps/remix-vite/app/routes/_index.tsx
+++ b/src/test-apps/remix-vite/app/routes/_index.tsx
@@ -1,13 +1,13 @@
 import type { ActionFunctionArgs } from "@remix-run/node";
 import { json, redirect, type LoaderFunctionArgs, defer } from "@remix-run/node";
 import type { MetaFunction } from "@remix-run/node";
-import { Link, useFetcher,  useSubmit } from "@remix-run/react"; 
+import { Link, useFetcher, useSubmit } from "@remix-run/react";
 import { Button } from "../components/Button";
+
 class Redis {
   constructor(url: string, options: any) {
     console.log("Redis constructor", url, options);
     console.error("Redis constructor", url, options);
-   
   }
   on(event: string, cb: any) {
     console.log("Redis on", event, cb);
@@ -22,43 +22,38 @@ export const meta: MetaFunction = () => {
     { name: "description", content: "Welcome to Remix!" },
   ];
 };
+
 export const redis = new Redis("url", {
   commandTimeout: 5000,
   enableAutoPipelining: true,
   maxRetriesPerRequest: 3,
 });
+
 redis.on("connect", () => console.debug("Redis connected"));
 redis.on("close", () => console.debug("Redis connection closed"));
 redis.on("reconnecting", () => console.log("Redis reconnecting"));
 redis.removeAllListeners("error");
 redis.on("error", console.error);
-// console.log(redis);
-/**
- * 
- * @param param0 
- * @returns 
- */
-export const loader = async ({ request , response }: LoaderFunctionArgs) => {
- 
+
+export const loader = async ({ request, response }: LoaderFunctionArgs) => {
   const test = new Promise((resolve, reject) => {
     setTimeout(() => {
       resolve("test");
     }, 1000);
-  })
-    const test1 = new Promise((resolve, reject) => {
+  });
+  const test1 = new Promise((resolve, reject) => {
     setTimeout(() => {
       reject("test");
     }, 1000);
-  })
+  });
   return defer({ message: "Hello World!", test, test1 });
-}; 
- 
- 
+};
+
 export const action = async ({ request }: ActionFunctionArgs) => {
   return redirect("/login");
 };
- 
-export default function Index() {  
+
+export default function Index() {
   const lFetcher = useFetcher({ key: "lfetcher"});
   const pFetcher = useFetcher({ key: "test"});
   const submit = useSubmit();
@@ -100,8 +95,23 @@ export default function Index() {
       <button onClick={() => submit(null, { method: "PUT", action: "/" })}>
         SUBMIT Action PUT
       </button> 
-     
-      <Link to="/login">Login</Link>
+
+      <h2>Test Links</h2>
+
+      <ul>
+        <li>
+          <Link to="/login">Login</Link>
+        </li>
+        <li>
+          <Link to="/file">File Route (file.tsx)</Link>
+        </li>
+        <li>
+          <Link to="/folder">Folder Route (folder/route.tsx)</Link>
+        </li>
+      </ul>
+
+      <h2>Resources</h2>
+
       <ul>
         <li>
           <a

--- a/src/test-apps/remix-vite/app/routes/file.tsx
+++ b/src/test-apps/remix-vite/app/routes/file.tsx
@@ -1,0 +1,10 @@
+import { Outlet } from "@remix-run/react";
+
+export default function File() {
+  return (
+    <div>
+      <h2>File Route</h2>
+      <Outlet />
+    </div>
+  );
+}

--- a/src/test-apps/remix-vite/app/routes/folder/route.tsx
+++ b/src/test-apps/remix-vite/app/routes/folder/route.tsx
@@ -1,0 +1,8 @@
+import { Outlet } from "@remix-run/react";
+
+export default function Folder() {
+    return <div>
+        <h2>Folder Route</h2>
+        <Outlet />
+    </div>
+}

--- a/src/vite/types.ts
+++ b/src/vite/types.ts
@@ -1,0 +1,13 @@
+export type OpenSourceData = {
+  type: "open-source";
+  data: {
+    /** The source file to open */
+    source?: string;
+    /** The remix route ID, usually discovered via the hook useMatches */
+    routeID?: string;
+    /** The line number in the source file */
+    line?: number;
+    /** The column number in the source file */
+    column?: number;
+  };
+};

--- a/src/vite/utils.ts
+++ b/src/vite/utils.ts
@@ -1,11 +1,10 @@
-
-
 import type { IncomingMessage, ServerResponse } from "http";
 import { Connect } from "vite";
+import fs from "fs";
 
 export async function processPlugins(pluginDirectoryPath: string) {
   const fs = await import("fs");
-  const { join } = await import("path"); 
+  const { join } = await import("path");
   const files = fs.readdirSync(pluginDirectoryPath);
   const allExports: { name: string; path: string }[] = [];
   files.forEach((file) => {
@@ -40,10 +39,28 @@ export const handleDevToolsViteRequest = (
     const dataToParse = Buffer.concat(chunks);
    try { const parsedData = JSON.parse(dataToParse.toString());
     cb(parsedData);} 
-    // eslint-disable-next-line no-empty
+      // eslint-disable-next-line no-empty
     catch(e){
 
     }
     res.write("OK");
   });
 };
+
+export function checkPath(routePath: string, extensions = [".tsx", ".jsx", ".ts", ".js"]) {
+  // Check if the path exists as a directory
+  if (fs.existsSync(routePath) && fs.lstatSync(routePath).isDirectory()) {
+    return { validPath: routePath, type: "directory" } as const;
+  }
+
+  // Check if the path exists as a file with one of the given extensions
+  for (const ext of extensions) {
+    const filePath = `${routePath}${ext}`;
+    if (fs.existsSync(filePath) && fs.lstatSync(filePath).isFile()) {
+      return { validPath: filePath, type: "file" } as const;
+    }
+  }
+
+  // If neither a file nor a directory is found
+  return null;
+}


### PR DESCRIPTION
# Description

I've found that the open in VSCode button wasn't working due to the file extensions being missing on the `exec` call and also the feature not currently working [with Remix's folder routes.](https://remix.run/docs/en/main/file-conventions/routes#folders-for-organization)

This PR is aimed for the main Open with VSCode feature in the "Active segments" section of the app.
![image](https://github.com/user-attachments/assets/aeb8ca99-910e-438b-aec6-98c3e2deab00)

I still believe there's a bit more fixing to do to the other implementations of this `open-source` method, but this is the first step.

This is a localized fix, so it doesn't affect the other implementations of `open-source`.

## Before
https://github.com/user-attachments/assets/10012ff9-5135-435e-b1be-526b9a4f7224

## After
https://github.com/user-attachments/assets/5d2359aa-0b1a-4f22-9598-efd0d0280e25


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I manually tested it, on Windows 11 23H3.
If there are more types of tests to be done I would appreciate some guidance as I'm a bit lost in that subject!

# Checklist:

- [x] My code follows the guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
